### PR TITLE
Remove `inline` keyword from database.h

### DIFF
--- a/database.h
+++ b/database.h
@@ -61,7 +61,7 @@ struct db_enumerator {
 /*
  * Field operations
  */
-inline int field_id(int i);
+int field_id(int i);
 abook_field *find_standard_field(char *key, int do_declare);
 abook_field *real_find_field(char *key, abook_field_list *list, int *nb);
 #define find_field(key, list)		real_find_field(key, list, NULL)


### PR DESCRIPTION
This is associated with #2 

AFAIK This is a C++/non-standard thing and causes the code not to
compile on gcc.