### PR TITLE
Search nickname/alias as well

### DIFF
--- a/database.c
+++ b/database.c
@@ -239,6 +239,9 @@ prepare_database_internals()
 	/* the only two mandatory fields */
 	declare_standard_field(NAME);
 	declare_standard_field(EMAIL);
+
+	/* search NICK as well */
+	declare_standard_field(NICK);
 }
 
 int


### PR DESCRIPTION
This enables searching nickname/alias by declaring NICK as a standard field, along with NAME and EMAIL